### PR TITLE
Properly set value of properties that have multiple values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,9 @@ export default function ({ Plugin, types: t }) {
       path.pushContainer('properties', t.property(
         'init',
         t.literal(key),
-        t.valueToNode(prefixed[key]))
+        Array.isArray(prefixed[key])
+          ? t.valueToNode(prefixed[key].join(`;${key}:`))
+          : t.valueToNode(prefixed[key]))
       );
     }
   }


### PR DESCRIPTION
Fixes #2. Just added a check for an array, if the value is an array then join the values.

For example, this:

``` js
class App {
  render() {
    return <div style={{ display: 'flex'; }} />
  }
}
```

becomes 

``` js
class App {
  render() {
    return <div style={{ display: '-webkit-flex; display: -ms-flex; display: flex;' }} />
  }
}
```

Which React will be able to properly set as the CSS for the node.
